### PR TITLE
Respect Loop's override durations, show Loop override symbols in selector, propose following common glucose range markers for Nightscout graph dot colors

### DIFF
--- a/Loop.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loop.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift",
-      "state" : {
-        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
-        "version" : "1.6.0"
-      }
-    },
-    {
       "identity" : "nightscoutclient",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gestrich/NightscoutClient.git",
@@ -48,7 +39,7 @@
     {
       "identity" : "onetimepassword",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattrubin/OneTimePassword",
+      "location" : "https://github.com/mattrubin/OneTimePassword.git",
       "state" : {
         "branch" : "develop",
         "revision" : "c3d8989f09a72ad7b00be7a45f1a5446e5f9e19b"

--- a/Loop.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loop.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift",
+      "state" : {
+        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "nightscoutclient",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gestrich/NightscoutClient.git",
@@ -39,7 +48,7 @@
     {
       "identity" : "onetimepassword",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattrubin/OneTimePassword.git",
+      "location" : "https://github.com/mattrubin/OneTimePassword",
       "state" : {
         "branch" : "develop",
         "revision" : "c3d8989f09a72ad7b00be7a45f1a5446e5f9e19b"

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
@@ -62,7 +62,8 @@ struct OverrideView: View {
                         
                         do {
                             //TODO: Set appropriate display symbol
-                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: 60)
+                            //Auggie - respect the override's duration (in minutes) as defined on Looping phone
+                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: selectedOverride.durationInMinutes)
                             showSheetView = false
                         } catch {
                             //TODO: Show user error

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
@@ -29,7 +29,8 @@ struct OverrideView: View {
                         Picker("Overrides", selection: $pickerCurrentlySelectedOverride) {
                             Text("None").tag(nil as NightscoutOverridePreset?)
                             ForEach(overidePresets, id: \.self) { overrideValue in
-                                Text("\(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
+                                //Auggie - adding the override symbol in the selector list
+                                Text("\(overrideValue.symbol) \(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
                             }
                         }.pickerStyle(.wheel)
                             .labelsHidden()
@@ -62,7 +63,8 @@ struct OverrideView: View {
                         
                         do {
                             //TODO: Set appropriate display symbol
-                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: 60)
+                            //Auggie - respecting the override duration define in Loop
+                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: selectedOverride.durationInMinutes)
                             showSheetView = false
                         } catch {
                             //TODO: Show user error

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
@@ -29,8 +29,7 @@ struct OverrideView: View {
                         Picker("Overrides", selection: $pickerCurrentlySelectedOverride) {
                             Text("None").tag(nil as NightscoutOverridePreset?)
                             ForEach(overidePresets, id: \.self) { overrideValue in
-                                //Auggie - adding the override symbol in the selector list
-                                Text("\(overrideValue.symbol) \(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
+                                Text("\(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
                             }
                         }.pickerStyle(.wheel)
                             .labelsHidden()
@@ -63,8 +62,7 @@ struct OverrideView: View {
                         
                         do {
                             //TODO: Set appropriate display symbol
-                            //Auggie - respecting the override duration define in Loop
-                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: selectedOverride.durationInMinutes)
+                            let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: 60)
                             showSheetView = false
                         } catch {
                             //TODO: Show user error

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
@@ -29,7 +29,7 @@ struct OverrideView: View {
                         Picker("Overrides", selection: $pickerCurrentlySelectedOverride) {
                             Text("None").tag(nil as NightscoutOverridePreset?)
                             ForEach(overidePresets, id: \.self) { overrideValue in
-                                Text("\(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
+                                Text("\(overrideValue.symbol) \(overrideValue.name)").tag(overrideValue as NightscoutOverridePreset?)
                             }
                         }.pickerStyle(.wheel)
                             .labelsHidden()

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -366,15 +366,16 @@ enum ColorType: Int, Plottable, CaseIterable, Comparable {
     init(quantity: HKQuantity) {
         let glucose = quantity.doubleValue(for:.milligramsPerDeciliter)
         switch glucose {
-        case 0..<60:
+        //Auggie - using commonly used ranges of <55, 70-180, >250
+        case 0..<55:
             self = ColorType.red
-        case 60..<80:
+        case 55..<70:
             self = ColorType.yellow
-        case 80..<180:
+        case 70..<180:
             self = ColorType.green
-        case 180...249:
+        case 180...250:
             self = ColorType.yellow
-        case 250...:
+        case 251...:
             self = ColorType.red
         default:
             assertionFailure("Uexpected range")

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -366,16 +366,15 @@ enum ColorType: Int, Plottable, CaseIterable, Comparable {
     init(quantity: HKQuantity) {
         let glucose = quantity.doubleValue(for:.milligramsPerDeciliter)
         switch glucose {
-        //Auggie - using commonly used ranges of <55, 70-180, >250
-        case 0..<55:
+        case 0..<60:
             self = ColorType.red
-        case 55..<70:
+        case 60..<80:
             self = ColorType.yellow
-        case 70..<180:
+        case 80..<180:
             self = ColorType.green
-        case 180...250:
+        case 180...249:
             self = ColorType.yellow
-        case 251...:
+        case 250...:
             self = ColorType.red
         default:
             assertionFailure("Uexpected range")

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -366,11 +366,11 @@ enum ColorType: Int, Plottable, CaseIterable, Comparable {
     init(quantity: HKQuantity) {
         let glucose = quantity.doubleValue(for:.milligramsPerDeciliter)
         switch glucose {
-        case 0..<60:
+        case 0..<55:
             self = ColorType.red
-        case 60..<80:
+        case 55..<70:
             self = ColorType.yellow
-        case 80..<180:
+        case 70..<180:
             self = ColorType.green
         case 180...249:
             self = ColorType.yellow


### PR DESCRIPTION
• OverrideView - propose showing override symbol in the selection list (now with a space between symbol and name)

• OverrideView - respect Loop’s defined duration for the override (now using the durationInMinutes which is provided, no more /60 required)

• NightscoutChartView - propose using commonly used ranges of <55, 70-180, >=250 for dot coloring; where <55 is urgent low, 70-180 is target range, and >=250 is urgent high.