### PR TITLE
Emoji shortcuts in carb entry for carb durations

### DIFF
--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -571,7 +571,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
-				DEVELOPMENT_TEAM = 5K844XFC6W;
+				DEVELOPMENT_TEAM = C6U8V99TR3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
@@ -602,7 +602,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
-				DEVELOPMENT_TEAM = 5K844XFC6W;
+				DEVELOPMENT_TEAM = C6U8V99TR3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/BolusInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/BolusInputView.swift
@@ -20,7 +20,7 @@ struct BolusInputView: View {
     @State private var errorText: String? = nil
     @FocusState private var bolusInputViewIsFocused: Bool
     
-    private let maxBolusAmount = 10.0 //TODO: Check Looper's max bolus amount
+    private let maxBolusAmount = 5.0 //TODO: Check Looper's max bolus amount
     private let unitFrameWidth: CGFloat = 20.0
     
     var body: some View {

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
@@ -14,14 +14,18 @@ struct CarbInputView: View {
     @Binding var showSheetView: Bool
     
     @State private var carbInput: String = ""
+    @State private var foodType: String = "" //TODO: Pass This back to Loop for descriptive entries
     @State private var duration: String = "3" //TODO: Get Looper's default medium duration
     @State private var submissionInProgress = false
     @State private var isPresentingConfirm: Bool = false
     @State private var usePickerConsumedDate: Bool = false
     @State private var pickerConsumedDate: Date = Date()
     @State private var showDatePickerSheet: Bool = false
+    @State private var showFoodEmojis: Bool = true
     @State private var errorText: String? = nil
+    @State var foodTypeWidth = 160.0
     @FocusState private var carbInputViewIsFocused: Bool
+    @FocusState private var durationInputFieldIsFocused: Bool
     
     private let minAbsorptionTimeInHours = 0.5
     private let maxAbsorptionTimeInHours = 8.0
@@ -113,6 +117,70 @@ struct CarbInputView: View {
             } label: {
                 Text("Time")
             }
+
+            //Auggie - absorption duration shortcuts per Loop timelines (0.5, 3, 5 hours)
+            //TODO: can we get durations from Loop directly via .slow, .medium, .fast?
+            //Create the "Food Type" row to hold emojis/typed description
+            HStack {
+                LabeledContent{
+                    TextField("", text: $foodType)
+                        .multilineTextAlignment(.trailing)
+                        //Capture the user's tap to override emoji shortcut entries
+                        //User can type in their own description (or go back to selecting emoji)
+                        .onTapGesture {
+                            showFoodEmojis = false
+                            foodTypeWidth = .infinity
+                        }
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                } label: {
+                    Text("Food Type")
+                }
+                .frame(width: foodTypeWidth, height: 30, alignment: .trailing)
+                Spacer()
+
+                //Fast carb entry emoji
+                if (showFoodEmojis) {
+                    Button(action: {}) {
+                        Text("🍭")
+                    }
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .onTapGesture {
+                        duration = "0.5"
+                    }
+                    Spacer()
+                    
+                    //Medium carb entry emoji
+                    Button(action: {}) {
+                        Text("🌮")
+                    }
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .onTapGesture {
+                        duration = "3"
+                    }
+                    Spacer()
+                    
+                    //Slow carb entry emoji
+                    Button(action: {}) {
+                        Text("🍕")
+                    }
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .onTapGesture {
+                        duration = "5"
+                    }
+                    Spacer()
+                    
+                    //Custom carb entry emoji, move focus to the duration input field
+                    Button(action: {}) {
+                        Text("🍽️")
+                    }
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .onTapGesture {
+                        duration = ""
+                        durationInputFieldIsFocused = true
+                    }
+                }
+            }
+            
             LabeledContent {
                 TextField(
                     "",
@@ -120,6 +188,7 @@ struct CarbInputView: View {
                 )
                 .multilineTextAlignment(.trailing)
                 .keyboardType(.decimalPad)
+                .focused($durationInputFieldIsFocused)
                 Text("hr")
                     .frame(width: unitFrameWidth)
             } label: {

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
@@ -17,7 +17,6 @@ struct CarbInputView: View {
     @State private var duration: String = "3" //TODO: Get Looper's default medium duration
     @State private var submissionInProgress = false
     @State private var isPresentingConfirm: Bool = false
-    @State private var usePickerConsumedDate: Bool = false
     @State private var pickerConsumedDate: Date = Date()
     @State private var showDatePickerSheet: Bool = false
     @State private var errorText: String? = nil
@@ -75,9 +74,6 @@ struct CarbInputView: View {
                     }
                 }.presentationDetents([.fraction(1/4)])
             }
-            .onChange(of: pickerConsumedDate) { newValue in
-                usePickerConsumedDate = true
-            }
         }
     }
     
@@ -104,11 +100,7 @@ struct CarbInputView: View {
                 Button {
                     showDatePickerSheet = true
                 } label: {
-                    if usePickerConsumedDate {
-                        Text(dateFormatter.string(from: pickerConsumedDate))
-                    } else {
-                        Text("Now")
-                    }
+                    Text(dateFormatter.string(from: pickerConsumedDate))
                 }
             } label: {
                 Text("Time")
@@ -176,7 +168,7 @@ struct CarbInputView: View {
         }
         
         let now = Date()
-        let consumedDate = self.usePickerConsumedDate ? pickerConsumedDate : now
+        let consumedDate = pickerConsumedDate
         
         let oldestAcceptedDate = now.addingTimeInterval(-60 * 60 * Double(maxPastCarbEntryHours))
         let latestAcceptedDate = now.addingTimeInterval(60 * 60 * Double(maxFutureCarbEntryHours))

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
@@ -14,7 +14,7 @@ struct CarbInputView: View {
     @Binding var showSheetView: Bool
     
     @State private var carbInput: String = ""
-    @State private var duration: String = "3" //TODO: Get Looper's default medium duration
+    @State private var duration: String = "0.5" //TODO: Get Looper's default medium duration
     @State private var submissionInProgress = false
     @State private var isPresentingConfirm: Bool = false
     @State private var pickerConsumedDate: Date = Date()
@@ -22,10 +22,11 @@ struct CarbInputView: View {
     @State private var errorText: String? = nil
     @FocusState private var carbInputViewIsFocused: Bool
     
+    private let maxCarbEntryAmountInGrams = 75.0 //TODO: Check Looper's max carb amount
     private let minAbsorptionTimeInHours = 0.5
     private let maxAbsorptionTimeInHours = 8.0
-    private let maxPastCarbEntryHours = 12
-    private let maxFutureCarbEntryHours = 1
+    private let maxPastCarbEntryHours = 10
+    private let maxFutureCarbEntryHours = 10
     private let unitFrameWidth: CGFloat = 20.0
     
     var body: some View {
@@ -159,7 +160,7 @@ struct CarbInputView: View {
     
     private func getCarbFieldValues() throws -> CarbInputViewFormValues {
         
-        guard let carbAmountInGrams = Double(carbInput), carbAmountInGrams > 0, carbAmountInGrams <= 250 else { //TODO: Check Looper's max carb amount
+        guard let carbAmountInGrams = Double(carbInput), carbAmountInGrams > 0, carbAmountInGrams <= maxCarbEntryAmountInGrams else {
             throw CarbInputViewError.invalidCarbAmount
         }
         

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/OverrideView.swift
@@ -61,7 +61,6 @@ struct OverrideView: View {
                         }
                         
                         do {
-                            //TODO: Set appropriate display symbol
                             //Auggie - respect the override's duration (in minutes) as defined on Looping phone
                             let _ = try await looperService.remoteDataSource.startOverride(overrideName: selectedOverride.name, overrideDisplay: "A", durationInMinutes: selectedOverride.durationInMinutes)
                             showSheetView = false

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/ChartsListView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/ChartsListView.swift
@@ -69,8 +69,8 @@ struct ChartsListView: View {
     }
     
     var loopGraphInterval: DateInterval {
-        let hoursLookback = 1.0
-        let hoursLookahead = 5.0
+        let hoursLookback = 2.0
+        let hoursLookahead = 4.0
         return DateInterval(start: Date().addingTimeInterval(60.0 * 60.0 * -hoursLookback), duration: 60.0 * 60.0 * hoursLookahead)
     }
     
@@ -87,7 +87,7 @@ struct ChartsListView: View {
         guard let cob = remoteDataSource.currentCOB?.cob else {
             return ""
         }
-        return String(format: "%.0f g", cob)
+        return String(format: "%.1f g", cob)
     }
     
     func formattedIOB() -> String {

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -37,13 +37,6 @@ struct NightscoutChartScrollView: View {
                         .padding([.top, .bottom]) //Prevent top Y label from clipping
                         .id(configuration.graphTag)
                         .modifier(PinchToZoom(minScale: minScale, maxScale: maxScale, scale: $currentScale))
-                        .onChange(of: currentScale) { newValue in
-                            scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)
-                        }
-                        //TODO clean up scrolling to land at a nice place so you see mostly real BGs and ~1h of predicted BGs
-                        .onChange(of: remoteDataSource.glucoseSamples, perform: { newValue in
-                            scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)
-                        })
                         //TODO clean up scrolling to land at a nice place so you see mostly real BGs and ~1h of predicted BGs
                         .onAppear(perform: {
                             scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -481,6 +481,6 @@ func interpolateYValueInRange(yRange: (y1: Double, y2: Double), referenceXRange:
 
 struct NightscoutChartConfiguration {
     let graphTotalDays = 1
-    let daysPerVisbleScrollFrame = 0.3
+    let daysPerVisbleScrollFrame = 3.0 / 24.0 //zoom to 3 hours
     let graphTag = 1000
 }

--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -144,7 +144,7 @@ struct NightscoutChartView: View {
     }
     
     func maxYValue() -> Double {
-        return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 400).doubleValue(for: settings.glucoseDisplayUnits)
+        return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 300).doubleValue(for: settings.glucoseDisplayUnits)
     }
     
     func formatGlucoseQuantity(_ quantity: HKQuantity) -> Double {


### PR DESCRIPTION
*Include Loop emoji functionality for entering meal durations

*Lollipop (0.5h), Taco (3h), Pizza (5h), and Plate (custom) included

*Include Loop-like functionality to clear out emojis and enter a custom meal note if preferred

*TODO: pass the meal emoji/meal description back to Loop for more descriptive remote entries in Loop carb history view