### PR TITLE
Add support for Fastlane + TestFlight deployment workflow

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -18,9 +18,20 @@ jobs:
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
         
-      # Create or update identifiers for app
+      # Create or update identifiers for Loop
       - name: Fastlane Provision
-        run: fastlane identifiers
+        run: fastlane loop_identifiers
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+
+      # Create or update identifiers for LoopCaregiver
+      - name: Fastlane Provision
+        run: fastlane caregiver_identifiers
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -19,7 +19,7 @@ jobs:
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
         
       # Create or update identifiers for Loop
-      - name: Fastlane Provision
+      - name: Fastlane Provision Loop
         run: fastlane loop_identifiers
         env:
           TEAMID: ${{ secrets.TEAMID }}
@@ -28,10 +28,10 @@ jobs:
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
           FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
-
-      # Create or update identifiers for LoopCaregiver
-      - name: Fastlane Provision
-        run: fastlane caregiver_identifiers
+      
+      # Create or update identifier for LoopCaregiver
+      - name: Fastlane Provision Caregiver
+        run: fastlane caregiver_identifier
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/build_loopcaregiver.yml
+++ b/.github/workflows/build_loopcaregiver.yml
@@ -1,4 +1,4 @@
-name: Build Loop
+name: Build LoopCaregiver
 on:
   workflow_dispatch:
 
@@ -20,9 +20,9 @@ jobs:
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
       
-      # Build signed Loop IPA file
+      # Build signed LoopCaregiver IPA file
       - name: Fastlane Build & Archive
-        run: fastlane loop_build
+        run: fastlane caregiver_build
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -33,7 +33,7 @@ jobs:
       
       # Upload to TestFlight
       - name: Fastlane upload to TestFlight
-        run: fastlane loop_release
+        run: fastlane caregiver_release
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -18,9 +18,20 @@ jobs:
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
         
-      # Create or update certificates for app
+      # Create or update certificates for Loop
       - name: Create Certificates
-        run: fastlane certs
+        run: fastlane loop_certs
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+
+      # Create or update certificates for LoopCaregiver
+      - name: Create Certificates
+        run: fastlane caregiver_certs
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -19,7 +19,7 @@ jobs:
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
         
       # Create or update certificates for Loop
-      - name: Create Certificates
+      - name: Create Loop Certificates
         run: fastlane loop_certs
         env:
           TEAMID: ${{ secrets.TEAMID }}
@@ -29,9 +29,9 @@ jobs:
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
           FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
 
-      # Create or update certificates for LoopCaregiver
-      - name: Create Certificates
-        run: fastlane caregiver_certs
+      # Create or update certificate for LoopCaregiver
+      - name: Create Caregiver Certificate
+        run: fastlane caregiver_cert
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/LoopCaregiver/LoopCaregiver.xcconfig
+++ b/LoopCaregiver/LoopCaregiver.xcconfig
@@ -3,6 +3,10 @@
 //  LoopCaregiver
 //
 
+// This is automatically disambiguated by development team, but you may choose to change this to
+// support running multiple apps simultaneously.
+CAREGIVER_BUNDLE_IDENTIFIER = com.${DEVELOPMENT_TEAM}.loopkit.LoopCaregiver
+
 // Code signing and provisioning [DEFAULT]
 LOOP_DEVELOPMENT_TEAM =
 

--- a/LoopCaregiver/LoopCaregiver.xcconfig
+++ b/LoopCaregiver/LoopCaregiver.xcconfig
@@ -1,0 +1,11 @@
+//
+//  LoopCaregiver.xcconfig
+//  LoopCaregiver
+//
+
+// Code signing and provisioning [DEFAULT]
+LOOP_DEVELOPMENT_TEAM =
+
+// Optional overrides
+#include? "LoopOverride.xcconfig"
+#include? "../LoopConfigOverride.xcconfig"

--- a/LoopCaregiver/LoopCaregiver.xcconfig
+++ b/LoopCaregiver/LoopCaregiver.xcconfig
@@ -5,7 +5,7 @@
 
 // This is automatically disambiguated by development team, but you may choose to change this to
 // support running multiple apps simultaneously.
-CAREGIVER_BUNDLE_IDENTIFIER = com.${DEVELOPMENT_TEAM}.loopkit.LoopCaregiver
+CAREGIVER_APP_BUNDLE_IDENTIFIER = com.${DEVELOPMENT_TEAM}.loopkit.LoopCaregiver
 
 // Code signing and provisioning [DEFAULT]
 LOOP_DEVELOPMENT_TEAM =

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.loopkit.LoopCaregiver;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -679,7 +679,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.loopkit.LoopCaregiver;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3D717B1629799E8A00B31B03 /* LoopCaregiver.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = LoopCaregiver.xcconfig; sourceTree = "<group>"; };
 		A90DB9532930F879004B58D3 /* CaregiverSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaregiverSettings.swift; sourceTree = "<group>"; };
 		A933181B2969FC17006CC3A2 /* Crypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A947025C2932299600FB3E59 /* ChartsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsListView.swift; sourceTree = "<group>"; };
@@ -344,6 +345,7 @@
 				A9EC197A291FEF940022D39F /* LoopCaregiver */,
 				A9EC1979291FEF940022D39F /* Products */,
 				A95F50BE292A602E00079AAF /* Frameworks */,
+				3D717B1629799E8A00B31B03 /* LoopCaregiver.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -507,6 +509,7 @@
 /* Begin XCBuildConfiguration section */
 		A9EC1984291FEF950022D39F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D717B1629799E8A00B31B03 /* LoopCaregiver.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -567,6 +570,7 @@
 		};
 		A9EC1985291FEF950022D39F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D717B1629799E8A00B31B03 /* LoopCaregiver.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -627,7 +631,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
-				DEVELOPMENT_TEAM = 5K844XFC6W;
+				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
@@ -659,7 +663,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
-				DEVELOPMENT_TEAM = 5K844XFC6W;
+				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Authentication required for Bolus and Carb delivery";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -647,7 +648,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_BUNDLE_IDENTIFIER)";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_APP_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -666,6 +667,7 @@
 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Authentication required for Bolus and Carb delivery";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -679,7 +681,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_BUNDLE_IDENTIFIER)";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CAREGIVER_APP_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		3D717B1629799E8A00B31B03 /* LoopCaregiver.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = LoopCaregiver.xcconfig; sourceTree = "<group>"; };
+		3DF4E0882980736C00E91E16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A90DB9532930F879004B58D3 /* CaregiverSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaregiverSettings.swift; sourceTree = "<group>"; };
 		A933181B2969FC17006CC3A2 /* Crypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A947025C2932299600FB3E59 /* ChartsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsListView.swift; sourceTree = "<group>"; };
@@ -360,6 +361,7 @@
 		A9EC197A291FEF940022D39F /* LoopCaregiver */ = {
 			isa = PBXGroup;
 			children = (
+				3DF4E0882980736C00E91E16 /* Info.plist */,
 				A96929302926E2B700B8BF43 /* Models */,
 				A98D4CB0292C38D100EFF5C6 /* Nightscout */,
 				A96929332926E57C00B8BF43 /* Views */,
@@ -633,15 +635,8 @@
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
-				INFOPLIST_KEY_NSFaceIDUsageDescription = "Authentication required for Bolus and Carb delivery";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LoopCaregiver/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -666,15 +661,8 @@
 				DEVELOPMENT_ASSET_PATHS = "\"LoopCaregiver/Preview Content\"";
 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Used for scanning QR codes from Looper's device";
-				INFOPLIST_KEY_NSFaceIDUsageDescription = "Authentication required for Bolus and Carb delivery";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LoopCaregiver/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/LoopCaregiver/LoopCaregiver/Info.plist
+++ b/LoopCaregiver/LoopCaregiver/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Used for scanning QR codes from Looper&apos;s device</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authentication required for Bolus and Carb delivery</string>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+</dict>
+</plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 platform :ios do
   desc "Build Loop"
-  lane :build_loop do
+  lane :loop_build do
     setup_ci if ENV['CI']
     
     update_project_team(
@@ -143,8 +143,8 @@ platform :ios do
     )
   end
 
-  desc "Push to TestFlight"
-  lane :release do
+  desc "Push Loop to TestFlight"
+  lane :loop_release do
     api_key = app_store_connect_api_key(
       key_id: "#{FASTLANE_KEY_ID}",
       issuer_id: "#{FASTLANE_ISSUER_ID}",
@@ -159,8 +159,8 @@ platform :ios do
     )
   end
 
-  desc "Provision Identifiers and Certificates"
-  lane :identifiers do
+  desc "Provision Loop Identifiers"
+  lane :loop_identifiers do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s
     
@@ -206,7 +206,7 @@ platform :ios do
   end
 
   desc "Provision Certificates"
-  lane :certs do
+  lane :loop_certs do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s
     
@@ -227,6 +227,143 @@ platform :ios do
         "com.#{TEAMID}.loopkit.Loop.LoopWatch", 
         "com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension",
         "com.#{TEAMID}.loopkit.Loop.SmallStatusWidget",
+      ]
+    )
+  end
+
+  desc "Build LoopCaregiver"
+  lane :caregiver_build do
+    setup_ci if ENV['CI']
+    
+    update_project_team(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      teamid: "#{TEAMID}"
+    )
+
+    api_key = app_store_connect_api_key(
+      key_id: "#{FASTLANE_KEY_ID}",
+      issuer_id: "#{FASTLANE_ISSUER_ID}",
+      key_content: "#{FASTLANE_KEY}"
+    )
+
+    previous_build_number = latest_testflight_build_number(
+      app_identifier: "com.#{TEAMID}.loopkit.LoopCaregiver",
+      api_key: api_key,
+    )
+
+    current_build_number = previous_build_number + 1
+
+    increment_build_number(
+      xcodeproj: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      build_number: current_build_number
+    )      
+    
+    match(
+      type: "appstore",
+      git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
+      app_identifier: [
+        "com.#{TEAMID}.loopkit.LoopCaregiver"
+      ]
+    )
+
+    previous_build_number = latest_testflight_build_number(
+      app_identifier: "com.#{TEAMID}.loopkit.LoopCaregiver",
+      api_key: api_key,
+    )
+
+    current_build_number = previous_build_number + 1
+
+    increment_build_number(
+      xcodeproj: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      build_number: current_build_number
+    )
+    
+    mapping = Actions.lane_context[
+      SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING
+    ]
+
+    update_code_signing_settings(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver"],
+      code_sign_identity: "iPhone Distribution",
+      targets: ["LoopCaregiver"]
+    )
+
+    gym(
+      export_method: "app-store",
+      scheme: "LoopCaregiver",
+      output_name: "LoopCaregiver.ipa",
+      configuration: "Release",
+      destination: 'generic/platform=iOS',
+      buildlog_path: 'buildlog'
+    )
+
+    copy_artifacts(
+      target_path: "artifacts",
+      artifacts: ["*.mobileprovision", "*.ipa", "*.dSYM.zip"]
+    )
+  end
+
+  desc "Push LoopCaregiver to TestFlight"
+  lane :caregiver_release do
+    api_key = app_store_connect_api_key(
+      key_id: "#{FASTLANE_KEY_ID}",
+      issuer_id: "#{FASTLANE_ISSUER_ID}",
+      key_content: "#{FASTLANE_KEY}"
+    )
+    
+    upload_to_testflight(
+      api_key: api_key,
+      skip_submission: false,
+      ipa: "LoopCaregiver.ipa",
+      skip_waiting_for_build_processing: true,
+    )
+  end
+
+  desc "Provision LoopCaregiver Identifiers"
+  lane :caregiver_identifiers do
+    setup_ci if ENV['CI']
+    ENV["MATCH_READONLY"] = false.to_s
+    
+    app_store_connect_api_key(
+      key_id: "#{FASTLANE_KEY_ID}",
+      issuer_id: "#{FASTLANE_ISSUER_ID}",
+      key_content: "#{FASTLANE_KEY}"
+    )
+
+    def configure_bundle_id(name, identifier, capabilities)
+      bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier) || Spaceship::ConnectAPI::BundleId.create(name: name, identifier: identifier)
+      capabilities.each { |capability|
+        bundle_id.create_capability(capability)
+      }
+    end
+
+    configure_bundle_id("LoopCaregiver", "com.#{TEAMID}.loopkit.LoopCaregiver", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::SIRIKIT
+    ])
+    
+  end
+
+  desc "Provision LoopCaregiver Certificates"
+  lane :caregiver_certs do
+    setup_ci if ENV['CI']
+    ENV["MATCH_READONLY"] = false.to_s
+    
+    app_store_connect_api_key(
+      key_id: "#{FASTLANE_KEY_ID}",
+      issuer_id: "#{FASTLANE_ISSUER_ID}",
+      key_content: "#{FASTLANE_KEY}"
+    )
+    
+    match(
+      type: "appstore",
+      force: true,
+      git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
+      app_identifier: [
+        "com.#{TEAMID}.loopkit.LoopCaregiver",
       ]
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -205,7 +205,7 @@ platform :ios do
     
   end
 
-  desc "Provision Certificates"
+  desc "Provision Loop Certificates"
   lane :loop_certs do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s
@@ -231,7 +231,7 @@ platform :ios do
     )
   end
 
-  desc "Build LoopCaregiver"
+  desc "Build Caregiver"
   lane :caregiver_build do
     setup_ci if ENV['CI']
     
@@ -304,7 +304,7 @@ platform :ios do
     )
   end
 
-  desc "Push LoopCaregiver to TestFlight"
+  desc "Push Caregiver to TestFlight"
   lane :caregiver_release do
     api_key = app_store_connect_api_key(
       key_id: "#{FASTLANE_KEY_ID}",
@@ -320,11 +320,11 @@ platform :ios do
     )
   end
 
-  desc "Provision LoopCaregiver Identifiers"
-  lane :caregiver_identifiers do
+  desc "Provision LoopCaregiver Identifier"
+  lane :caregiver_identifier do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s
-    
+
     app_store_connect_api_key(
       key_id: "#{FASTLANE_KEY_ID}",
       issuer_id: "#{FASTLANE_ISSUER_ID}",
@@ -339,16 +339,12 @@ platform :ios do
     end
 
     configure_bundle_id("LoopCaregiver", "com.#{TEAMID}.loopkit.LoopCaregiver", [
-      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::SIRIKIT
     ])
-    
+
   end
 
-  desc "Provision LoopCaregiver Certificates"
-  lane :caregiver_certs do
+  desc "Provision Caregiver Certificate"
+  lane :caregiver_cert do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,7 +320,7 @@ platform :ios do
     )
   end
 
-  desc "Provision LoopCaregiver Identifier"
+  desc "Provision Caregiver Identifier"
   lane :caregiver_identifier do
     setup_ci if ENV['CI']
     ENV["MATCH_READONLY"] = false.to_s

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -1,6 +1,6 @@
 # Using Github Actions + FastLane to deploy to TestFlight
 
-These instructions allow you to build Loop without having access to a Mac. They also allow you to easily install Loop on phones that are not connected to your computer. So you can send builds and updates to those you care for easily, or have an easy to access backup if you run Loop for yourself. You do not need to worry about correct Xcode/Mac versions either. An app built using this method can easily be deployed to newer versions of iOS, as soon as they are available.
+These instructions allow you to build Loop (and optionally, LoopCaregiver) without having access to a Mac. They also allow you to easily install Loop on phones that are not connected to your computer. So you can send builds and updates to those you care for easily, or have an easy to access backup if you run Loop for yourself. You do not need to worry about correct Xcode/Mac versions either. An app built using this method can easily be deployed to newer versions of iOS, as soon as they are available.
 
 The setup steps are somewhat involved, but nearly all are one time steps. Subsequent builds are trivial.  Note that TestFlight requires apple id accounts 13 years or older. Your app must be updated once every 90 days, but it's a simple click to make a new build and can be done from anywhere.
 
@@ -93,6 +93,21 @@ If you have created a Loop app in App Store Connect before, you can skip this se
 
 You do not need to fill out the next form. That is for submitting to the app store.
 
+## Create LoopCaregiver App in App Store Connect (Optional)
+
+If you have created a LoopCaregiver app in App Store Connect before with a bundle ID that matches `com.TEAMID.loopkit.LoopCaregiver`, with TEAMID matching your team id, you can skip this section as well.
+
+1. Go to the [apps list](https://appstoreconnect.apple.com/apps) on App Store Connect and click the blue "plus" icon to create a New App.
+    * Select "iOS".
+    * Select a name: this will have to be unique, so you may have to try a few different names here, but it will not be the name you see on your phone, so it's not that important.
+    * Select your primary language.
+    * Choose the bundle ID that matches `com.TEAMID.loopkit.LoopCaregiver`, with TEAMID matching your team id.
+    * SKU can be anything; e.g. "123".
+    * Select "Full Access".
+1. Click Create
+
+You do not need to fill out the next form. That is for submitting to the app store.
+
 ## Create Building Certficates
 
 1. Go back to the "Actions" tab of your LoopWorkspace repository in github.
@@ -106,6 +121,17 @@ You do not need to fill out the next form. That is for submitting to the app sto
 1. Select "Build Loop".
 1. Click "Run Workflow", select your branch, and tap the green button.
 1. You have some time now. Go enjoy a coffee. The build should take about 20-30 minutes.
+1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps).
+1. For each phone/person you would like to support Loop on:
+    * Add them in [Users and Access](https://appstoreconnect.apple.com/access/users) on App Store Connect.
+    * Add them to your TestFlight Internal Testing group.
+
+## Build LoopCaregiver (Optional)
+
+1. Click on the "Actions" tab of your LoopWorkspace repository.
+1. Select "Build LoopCaregiver".
+1. Click "Run Workflow", select your branch, and tap the green button.
+1. You have some time now. Go enjoy a coffee. The build should take about 10-15 minutes.
 1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps).
 1. For each phone/person you would like to support Loop on:
     * Add them in [Users and Access](https://appstoreconnect.apple.com/access/users) on App Store Connect.


### PR DESCRIPTION
This PR includes a few changes. The core changes to the Fastfile and the addition of a LoopCaregiver.yml, as well as the addition and integration of the `CAREGIVER_APP_BUNDLE_IDENTIFIER` are contributions from @bjornoleh.

Here is a high-level summary of the changes:
* Added a LoopCaregiver.xcconfig that pulls in the `$(LOOP_DEVELOPMENT_TEAM)` from LoopConfigOverride.xcconfig and uses it as well in the default app bundle ID.
* Added a LoopCaregiver.yml that allows LoopCaregiver to be built and deployed from GH Actions.
* Updated the Fastfile and other workflow YAMLs to provision the LoopCaregiver identifier and certificate.
* Declared use of standard encryption to avoid the need to declare the use of encryption manually in TestFlight.
* Updated testflight.md to include instructions for building LoopCaregiver

This PR contains one **BREAKING CHANGE** for users that have already deployed, either locally or via App Store Connect/TestFlight.  The default BUNDLE ID has now changed from `org.loopkit.LoopCaregiver` to the value of `$(CAREGIVER_APP_BUNDLE_IDENTIFIER)`, which evaluates to `com.${DEVELOPMENT_TEAM}.loopkit.LoopCaregiver` by default. The consequence of this change is that Caregiver users will lose their settings and need to re-add their Loopers unless they change the `$(CAREGIVER_APP_BUNDLE_IDENTIFIER)` to match the old default value or the value of the identifier that they previously pushed to TestFlight.

Let me know if you have any questions!